### PR TITLE
Major updates/reworks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,3 +18,4 @@ Dockerfile**
 Makefile**
 render_template
 **/Cargo.lock
+Cargo.lock

--- a/.github/workflows/rust-musl.yml
+++ b/.github/workflows/rust-musl.yml
@@ -238,7 +238,7 @@ jobs:
   # ###
   # Building the final MUSL Based images including the rust toolchain.
   musl-base:
-    name: Build MUSL Base Image - ${{ matrix.env.IMAGE_TAG }} - (OpenSSL v${{ matrix.openssl_version }})
+    name: Build MUSL Base Image - ${{ matrix.env.IMAGE_TAG }}
     needs: [build_vars]
     runs-on: ubuntu-latest
     env:
@@ -247,17 +247,8 @@ jobs:
       HAVE_QUAY_LOGIN: ${{ secrets.QUAY_USERNAME != '' && secrets.QUAY_TOKEN != '' }}
     if: ${{ github.repository == 'BlackDex/rust-musl' }}
     strategy:
-      # max-parallel: 2 # Use this when using `act`, since this could use a lot of resources
       fail-fast: false
       matrix:
-        openssl_version:
-          - "1.1.1w"
-          - "3.0.11"
-        include:
-          - openssl_version: "1.1.1w"
-            openssl_docker_tag: ""
-          - openssl_version: "3.0.11"
-            openssl_docker_tag: "-openssl3"
         env:
           - IMAGE_TAG: x86_64-musl
             TARGET: x86_64-unknown-linux-musl
@@ -300,20 +291,28 @@ jobs:
         shell: bash
         run: |
             echo "base_tags_stable=" \
-            "@RGSTRY@blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}${{ matrix.openssl_docker_tag }}," \
-            "@RGSTRY@blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-${{ needs.build_vars.outputs.stable_version }}${{ matrix.openssl_docker_tag }}," \
-            "@RGSTRY@blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-stable${{ matrix.openssl_docker_tag }}," \
-            "@RGSTRY@blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-stable-${{ needs.build_vars.outputs.stable_version }}${{ matrix.openssl_docker_tag }}" \
+            "@RGSTRY@blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}," \
+            "@RGSTRY@blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-openssl3," \
+            "@RGSTRY@blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-${{ needs.build_vars.outputs.stable_version }}," \
+            "@RGSTRY@blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-${{ needs.build_vars.outputs.stable_version }}-openssl3," \
+            "@RGSTRY@blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-stable," \
+            "@RGSTRY@blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-stable-openssl3," \
+            "@RGSTRY@blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-stable-${{ needs.build_vars.outputs.stable_version }}," \
+            "@RGSTRY@blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-stable-${{ needs.build_vars.outputs.stable_version }}-openssl3" \
             | tr -d ' ' | tee -a "${GITHUB_ENV}"
 
             echo "base_tags_stable_vw=" \
-            "@RGSTRY@blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-${{ needs.build_vars.outputs.vaultwarden_version }}${{ matrix.openssl_docker_tag }}," \
-            "@RGSTRY@blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-stable-${{ needs.build_vars.outputs.vaultwarden_version }}${{ matrix.openssl_docker_tag }}" \
+            "@RGSTRY@blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-${{ needs.build_vars.outputs.vaultwarden_version }}," \
+            "@RGSTRY@blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-${{ needs.build_vars.outputs.vaultwarden_version }}-openssl3," \
+            "@RGSTRY@blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-stable-${{ needs.build_vars.outputs.vaultwarden_version }}," \
+            "@RGSTRY@blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-stable-${{ needs.build_vars.outputs.vaultwarden_version }}-openssl3" \
             | tr -d ' ' | tee -a "${GITHUB_ENV}"
 
             echo "base_tags_nightly=" \
-            "@RGSTRY@blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-nightly${{ needs.build_vars.outputs.nightly_tag_postfix }}${{ matrix.openssl_docker_tag }}," \
-            "@RGSTRY@blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-nightly-${{ needs.build_vars.outputs.nightly_date }}${{ matrix.openssl_docker_tag }}" \
+            "@RGSTRY@blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-nightly${{ needs.build_vars.outputs.nightly_tag_postfix }}," \
+            "@RGSTRY@blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-nightly${{ needs.build_vars.outputs.nightly_tag_postfix }}-openssl3," \
+            "@RGSTRY@blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-nightly-${{ needs.build_vars.outputs.nightly_date }}," \
+            "@RGSTRY@blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-nightly-${{ needs.build_vars.outputs.nightly_date }}-openssl3" \
             | tr -d ' ' | tee -a "${GITHUB_ENV}"
 
       - name: Login to DockerHub
@@ -324,14 +323,14 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Tags for DockerHub
-        if: ${{ env.ACT || env.HAVE_DOCKERHUB_LOGIN == 'true' }}
+        if: ${{ env.HAVE_DOCKERHUB_LOGIN == 'true' }}
         shell: bash
         run: |
-          echo "tags_stable=$(echo "${base_tags_stable}" | sed 's#@RGSTRY@##g')" \
+          echo "tags_stable=$(echo "${base_tags_stable}" | sed 's#@RGSTRY@#docker.io/#g')" \
             | tee -a "${GITHUB_ENV}"
-          echo "tags_stable_vw=$(echo "${base_tags_stable_vw}" | sed 's#@RGSTRY@##g')" \
+          echo "tags_stable_vw=$(echo "${base_tags_stable_vw}" | sed 's#@RGSTRY@#docker.io/#g')" \
             | tee -a "${GITHUB_ENV}"
-          echo "tags_nightly=$(echo "${base_tags_nightly}" | sed 's#@RGSTRY@##g')" \
+          echo "tags_nightly=$(echo "${base_tags_nightly}" | sed 's#@RGSTRY@#docker.io/#g')" \
             | tee -a "${GITHUB_ENV}"
 
       - name: Login to ghcr.io
@@ -362,7 +361,7 @@ jobs:
           password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Tags for quay.io
-        if: ${{ env.ACT || env.HAVE_QUAY_LOGIN == 'true' }}
+        if: ${{ env.HAVE_QUAY_LOGIN == 'true' }}
         shell: bash
         run: |
           echo "tags_stable=${tags_stable:+${tags_stable},}$(echo "${base_tags_stable}" | sed 's#@RGSTRY@#quay.io/#g')" \
@@ -383,11 +382,11 @@ jobs:
           #
           # Check if we are running this via act or not and determine the caching method
           if [[ -n "${ACT}" ]]; then
-            github_output "cache_from" "blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}${{ matrix.openssl_docker_tag }}"
+            github_output "cache_from" "blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}"
             github_output "cache_to" ""
           else
-            github_output "cache_from" "type=gha,scope=${{ matrix.env.IMAGE_TAG }}${{ matrix.openssl_docker_tag }}"
-            github_output "cache_to" "type=gha,scope=${{ matrix.env.IMAGE_TAG }}${{ matrix.openssl_docker_tag }}"
+            github_output "cache_from" "type=gha,scope=${{ matrix.env.IMAGE_TAG }}"
+            github_output "cache_to" "type=gha,scope=${{ matrix.env.IMAGE_TAG }}"
           fi
           #
 
@@ -415,11 +414,10 @@ jobs:
             TARGET=${{ matrix.env.TARGET }}
             IMAGE_TAG=${{ matrix.env.IMAGE_TAG }}${{ env.STABLE_TOOLCHAIN_POSTFIX }}
             OPENSSL_ARCH=${{ matrix.env.OPENSSL_ARCH }}
-            OPENSSL_VERSION=${{ matrix.openssl_version }}
             ARCH_CPPFLAGS=${{ matrix.env.ARCH_CPPFLAGS }}
             RUST_CHANNEL=stable
             RUSTC_HASH=${{ needs.build_vars.outputs.stable_hash }}
-          tags: blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}${{ matrix.openssl_docker_tag }}-test
+          tags: blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-test
           cache-from: ${{ steps.docker_cache.outputs.cache_from }}
           cache-to: ${{ steps.docker_cache.outputs.cache_to }}
 
@@ -427,33 +425,29 @@ jobs:
         # Skip during nightly builds
         if: ${{ needs.build_vars.outputs.stable_trigger || !needs.build_vars.outputs.nightly_trigger }}
         run: |
-          # Clean leftover files from previous run if they exists
-          rm -vf "$(pwd)/test/multicrate/Cargo.lock"
           # Run the test
           docker run --rm \
-            -v cargo-cache:/root/.cargo/registry \
+            -v cargo-cache-${{ matrix.env.IMAGE_TAG }}:/root/.cargo/registry \
             -v "$(pwd)/test/multicrate":/home/rust/src \
             --tmpfs /home/rust/src/target:rw,exec,mode=1777 \
             -e RUST_BACKTRACE=1 \
             -e RUSTFLAGS="${{ matrix.env.XTRA_RUSTFLAGS }}-Clink-arg=-s" \
-            blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}${{ matrix.openssl_docker_tag }}-test bash -c 'cargo -Vv ; rustc -Vv ; cargo update ; cargo build --release'
+            blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-test bash -c 'rm -vf Cargo.lock ; cargo -Vv ; rustc -Vv ; cargo update ; cargo build --release'
 
       - name: Test Docker Image (PQ15) - Rust Current Stable
         # Skip during nightly builds
         if: ${{ needs.build_vars.outputs.stable_trigger || !needs.build_vars.outputs.nightly_trigger }}
         continue-on-error: true
         run: |
-          # Clean leftover files from previous run if they exists
-          rm -vf "$(pwd)/test/multicrate/Cargo.lock"
           # Run the test
           docker run --rm \
-            -v cargo-cache:/root/.cargo/registry \
+            -v cargo-cache-${{ matrix.env.IMAGE_TAG }}:/root/.cargo/registry \
             -v "$(pwd)/test/multicrate":/home/rust/src \
             --tmpfs /home/rust/src/target:rw,exec,mode=1777 \
             -e RUST_BACKTRACE=1 \
             -e PQ_LIB_DIR="/usr/local/musl/pq15/lib" \
             -e RUSTFLAGS="${{ matrix.env.XTRA_RUSTFLAGS }}-Clink-arg=-s" \
-            blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}${{ matrix.openssl_docker_tag }}-test bash -c 'cargo -Vv ; rustc -Vv ; cargo update ; cargo build --release'
+            blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-test bash -c 'rm -vf Cargo.lock ; cargo -Vv ; rustc -Vv ; cargo update ; cargo build --release'
 
       - name: Docker Push - Rust Current Stable
         # Skip during nightly builds
@@ -468,10 +462,9 @@ jobs:
             TARGET=${{ matrix.env.TARGET }}
             IMAGE_TAG=${{ matrix.env.IMAGE_TAG }}${{ env.STABLE_TOOLCHAIN_POSTFIX }}
             OPENSSL_ARCH=${{ matrix.env.OPENSSL_ARCH }}
-            OPENSSL_VERSION=${{ matrix.openssl_version }}
             ARCH_CPPFLAGS=${{ matrix.env.ARCH_CPPFLAGS }}
             RUST_CHANNEL=stable
-            RUSTC_HASH=${{ needs.build_vars.outputs.stable_rustc_hash }}
+            RUSTC_HASH=${{ needs.build_vars.outputs.stable_hash }}
           tags: ${{ env.tags_stable }}
           cache-from: ${{ steps.docker_cache.outputs.cache_from }}
           cache-to: ${{ steps.docker_cache.outputs.cache_to }}
@@ -501,10 +494,9 @@ jobs:
             TARGET=${{ matrix.env.TARGET }}
             IMAGE_TAG=${{ matrix.env.IMAGE_TAG }}${{ env.VAULTWARDEN_TOOLCHAIN_POSTFIX }}
             OPENSSL_ARCH=${{ matrix.env.OPENSSL_ARCH }}
-            OPENSSL_VERSION=${{ matrix.openssl_version }}
             ARCH_CPPFLAGS=${{ matrix.env.ARCH_CPPFLAGS }}
             RUST_CHANNEL=${{ needs.build_vars.outputs.vaultwarden_version }}
-          tags: blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}${{ matrix.openssl_docker_tag }}-vw-test
+          tags: blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-vw-test
           cache-from: ${{ steps.docker_cache.outputs.cache_from }}
           cache-to: ${{ steps.docker_cache.outputs.cache_to }}
 
@@ -512,8 +504,6 @@ jobs:
         # Skip during nightly builds
         if: ${{ needs.build_vars.outputs.stable_version != needs.build_vars.outputs.vaultwarden_version && (needs.build_vars.outputs.stable_trigger || !needs.build_vars.outputs.nightly_trigger) }}
         run: |
-          # Clean leftover files from previous run if they exists
-          rm -vf "$(pwd)/test/multicrate/Cargo.lock"
           # Run the test
           docker run --rm \
             -v cargo-cache:/root/.cargo/registry \
@@ -521,15 +511,13 @@ jobs:
             --tmpfs /home/rust/src/target:rw,exec,mode=1777 \
             -e RUST_BACKTRACE=1 \
             -e RUSTFLAGS="${{ matrix.env.XTRA_RUSTFLAGS }}-Clink-arg=-s" \
-            blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}${{ matrix.openssl_docker_tag }}-vw-test bash -c 'cargo -Vv ; rustc -Vv ; cargo update ; cargo build --release'
+            blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-vw-test bash -c 'rm -vf Cargo.lock ; cargo -Vv ; rustc -Vv ; cargo update ; cargo build --release'
 
       - name: Test Docker Image (PQ15) - Rust Vaultwarden Stable
         # Skip during nightly builds
         if: ${{ needs.build_vars.outputs.stable_version != needs.build_vars.outputs.vaultwarden_version && (needs.build_vars.outputs.stable_trigger || !needs.build_vars.outputs.nightly_trigger) }}
         continue-on-error: true
         run: |
-          # Clean leftover files from previous run if they exists
-          rm -vf "$(pwd)/test/multicrate/Cargo.lock"
           # Run the test
           docker run --rm \
             -v cargo-cache:/root/.cargo/registry \
@@ -538,7 +526,7 @@ jobs:
             -e RUST_BACKTRACE=1 \
             -e PQ_LIB_DIR="/usr/local/musl/pq15/lib" \
             -e RUSTFLAGS="${{ matrix.env.XTRA_RUSTFLAGS }}-Clink-arg=-s" \
-            blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}${{ matrix.openssl_docker_tag }}-vw-test bash -c 'cargo -Vv ; rustc -Vv ; cargo update ; cargo build --release'
+            blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-vw-test bash -c 'rm -vf Cargo.lock ; cargo -Vv ; rustc -Vv ; cargo update ; cargo build --release'
 
       - name: Docker Push - Rust Vaultwarden Stable
         # Skip during nightly builds
@@ -553,7 +541,6 @@ jobs:
             TARGET=${{ matrix.env.TARGET }}
             IMAGE_TAG=${{ matrix.env.IMAGE_TAG }}${{ env.VAULTWARDEN_TOOLCHAIN_POSTFIX }}
             OPENSSL_ARCH=${{ matrix.env.OPENSSL_ARCH }}
-            OPENSSL_VERSION=${{ matrix.openssl_version }}
             ARCH_CPPFLAGS=${{ matrix.env.ARCH_CPPFLAGS }}
             RUST_CHANNEL=${{ needs.build_vars.outputs.vaultwarden_version }}
           tags: ${{ env.tags_stable_vw }}
@@ -583,17 +570,14 @@ jobs:
             TARGET=${{ matrix.env.TARGET }}
             IMAGE_TAG=${{ matrix.env.IMAGE_TAG }}${{ env.NIGHTLY_TOOLCHAIN_POSTFIX }}
             OPENSSL_ARCH=${{ matrix.env.OPENSSL_ARCH }}
-            OPENSSL_VERSION=${{ matrix.openssl_version }}
             ARCH_CPPFLAGS=${{ matrix.env.ARCH_CPPFLAGS }}
             RUST_CHANNEL=nightly-${{ needs.build_vars.outputs.nightly_date }}
-          tags: blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-nightly${{ matrix.openssl_docker_tag }}-test
+          tags: blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-nightly-test
           cache-from: ${{ steps.docker_cache.outputs.cache_from }}
           cache-to: ${{ steps.docker_cache.outputs.cache_to }}
 
       - name: Test Docker Image - Rust Nightly
         run: |
-          # Clean leftover files from previous run if they exists
-          rm -vf "$(pwd)/test/multicrate/Cargo.lock"
           # Run the test
           docker run --rm \
             -v cargo-cache:/root/.cargo/registry \
@@ -601,13 +585,11 @@ jobs:
             --tmpfs /home/rust/src/target:rw,exec,mode=1777 \
             -e RUST_BACKTRACE=1 \
             -e RUSTFLAGS="${{ matrix.env.XTRA_RUSTFLAGS }}-Clink-arg=-s" \
-            blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-nightly${{ matrix.openssl_docker_tag }}-test bash -c 'cargo -Vv ; rustc -Vv ; cargo update ; cargo build --release'
+            blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-nightly-test bash -c 'rm -vf Cargo.lock ; cargo -Vv ; rustc -Vv ; cargo update ; cargo build --release'
 
       - name: Test Docker Image (PQ15) - Rust Nightly
         continue-on-error: true
         run: |
-          # Clean leftover files from previous run if they exists
-          rm -vf "$(pwd)/test/multicrate/Cargo.lock"
           # Run the test
           docker run --rm \
             -v cargo-cache:/root/.cargo/registry \
@@ -616,7 +598,7 @@ jobs:
             -e RUST_BACKTRACE=1 \
             -e PQ_LIB_DIR="/usr/local/musl/pq15/lib" \
             -e RUSTFLAGS="${{ matrix.env.XTRA_RUSTFLAGS }}-Clink-arg=-s" \
-            blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-nightly${{ matrix.openssl_docker_tag }}-test bash -c 'cargo -Vv ; rustc -Vv ; cargo update ; cargo build --release'
+            blackdex/rust-musl:${{ matrix.env.IMAGE_TAG }}-nightly-test bash -c 'rm -vf Cargo.lock ; cargo -Vv ; rustc -Vv ; cargo update ; cargo build --release'
 
       - name: Docker Push - Rust Nightly
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
@@ -629,7 +611,6 @@ jobs:
             TARGET=${{ matrix.env.TARGET }}
             IMAGE_TAG=${{ matrix.env.IMAGE_TAG }}${{ env.NIGHTLY_TOOLCHAIN_POSTFIX }}
             OPENSSL_ARCH=${{ matrix.env.OPENSSL_ARCH }}
-            OPENSSL_VERSION=${{ matrix.openssl_version }}
             ARCH_CPPFLAGS=${{ matrix.env.ARCH_CPPFLAGS }}
             RUST_CHANNEL=nightly-${{ needs.build_vars.outputs.nightly_date }}
           tags: ${{ env.tags_nightly }}

--- a/Dockerfile.musl-base
+++ b/Dockerfile.musl-base
@@ -43,9 +43,6 @@ RUN apt-get update && \
 # Define the target and openssl architecture to use during build
 ARG TARGET=x86_64-unknown-linux-musl
 ARG OPENSSL_ARCH=linux-x86_64
-# Update the OpenSSL version in the rust-musl.yml workflow.
-# Currently 1.1.1w / 3.0.11
-ARG OPENSSL_VERSION="1.1.1w"
 ARG ARCH_CPPFLAGS=
 
 ENV TARGET="${TARGET}" \
@@ -56,17 +53,17 @@ ENV TARGET="${TARGET}" \
     TARGET_CC="${TARGET}-gcc" \
     TARGET_CXX="${TARGET}-g++" \
     TARGET_RANLIB="${TARGET}-ranlib" \
-    TARGET_LDFLAGS="-flto -s -pie -static -L/usr/local/musl/lib" \
+    TARGET_LDFLAGS="-flto -s -pie -L/usr/local/musl/lib" \
     RUST_MUSL_CROSS_TARGET="${TARGET}" \
     SYSROOT="/usr/local/musl/${TARGET}" \
     # Library versions
-    SSL_VER="${OPENSSL_VERSION}" \
+    SSL_VER="3.0.11" \
     CURL_VER="8.3.0" \
     ZLIB_VER="1.3" \
     PQ_11_VER="11.21" \
     PQ_15_VER="15.4" \
     SQLITE_VER="3430100" \
-    MARIADB_VER="3.3.5"
+    MARIADB_VER="3.3.7"
 
 WORKDIR /tmp
 
@@ -85,7 +82,8 @@ RUN echo "zlib" && \
     LDFLAGS="${TARGET_LDFLAGS}" \
     CPPFLAGS="-I${TARGET_PREFIX}/include ${ARCH_CPPFLAGS}" \
     C_INCLUDE_PATH="${TARGET_PREFIX}/include" \
-    CC="${TARGET_CC} -O2 -fstack-protector-strong -flto -ffat-lto-objects -fPIE -pie -static --static" \
+    CFLAGS="-O2 -fstack-clash-protection -fstack-protector-strong -flto -ffat-lto-objects -fPIE -pie -fpic --static -Wl,-z,noexecstack -Wl,-z,relro,-z,now" \
+    CC="${TARGET_CC}" \
     ./configure \
       --static \
       --prefix="${TARGET_PREFIX}" && \
@@ -106,29 +104,51 @@ RUN echo "OpenSSL" && \
     LDFLAGS="${TARGET_LDFLAGS}" \
     CPPFLAGS="-I${TARGET_PREFIX}/include ${ARCH_CPPFLAGS}" \
     C_INCLUDE_PATH="${TARGET_PREFIX}/include" \
-    CC="${TARGET_CC} -O2 -fstack-protector-strong -flto -ffat-lto-objects -fPIC -pie -static --static" \
+    CFLAGS="-O2 -fstack-clash-protection -fstack-protector-strong -flto -ffat-lto-objects -fPIE -pie -fpic --static -Wl,-z,noexecstack -Wl,-z,relro,-z,now" \
+    CC="${TARGET_CC}" \
     ./Configure \
-      ${OPENSSL_ARCH} \
+      # Disable several features, either insecure or not working that well on musl libc or not needed at all
       no-dso \
       no-shared \
       no-ssl3 \
-      no-rc5 \
-      no-md2 \
-      no-mdc2 \
-      no-idea \
+      no-tests \
       no-unit-test \
       no-comp \
       no-zlib \
       no-zlib-dynamic \
+      ## rust-openssl currently enables legacy, lets do the same here
+      # no-legacy \
+      no-md2 \
+      no-rc5 \
+      no-weak-ssl-ciphers \
+      no-camellia \
+      no-idea \
+      no-seed \
+      no-engine \
       no-async \
-      -fPIC -pie -static --static \
+      # Some Alpine defined configure arguments
+      no-mdc2 \
+      no-ec2m \
+      # Set which OpenSSL Architecture needs to be used
+      ${OPENSSL_ARCH} \
       --openssldir="${TARGET_PREFIX}/ssl" \
       --libdir="${TARGET_PREFIX}/lib" \
       --prefix="${TARGET_PREFIX}" && \
-    C_INCLUDE_PATH="${TARGET_PREFIX}/include" make -j"$(nproc)" depend && \
-    make -j"$(nproc)" && \
-    make install_sw install_ssldirs && \
+    make -j"$(nproc)" depend && \
+    make -j"$(nproc)" build_libs && \
+    make -j"$(nproc)" build_programs && \
+    make install_dev install_runtime && \
     cd /tmp && rm -rf "openssl-${SSL_VER}" && \
+    # # Fix libcrypto for armv6 which does not have libatomic by default
+    # cd /usr/local/musl/lib && \
+    # mkdir -v libcrypto_merge && cd libcrypto_merge && \
+    # # Extract the generated .a files
+    # "${TARGET_AR}" x "${SYSROOT}/lib/libatomic.a" && \
+    # "${TARGET_AR}" x ../libcrypto.a && \
+    # # Merge all these files again into one libcrypto.a file
+    # "${TARGET_AR}" csr libcrypto.a ./*.o && \
+    # # Move and cleanup
+    # mv -vf libcrypto.a ../libcrypto.a && \
     # Move the compiled binaries out off the main musl bin to tbin
     mv -t "${TARGET_PREFIX}/tbin" "${TARGET_PREFIX}/bin/openssl" "${TARGET_PREFIX}/bin/c_rehash" && \
     # Default cleanups
@@ -139,6 +159,8 @@ RUN echo "OpenSSL" && \
 RUN echo "libcurl" && \
     curl -sSL "https://curl.se/download/curl-${CURL_VER}.tar.gz" | tar xz && \
     cd "curl-${CURL_VER}" && \
+    mv -vf "/usr/local/musl/${TARGET}/lib/libatomic.la" "/usr/local/musl/${TARGET}/lib/libatomic.la_disabled" && \
+    if [[ "${TARGET}" == "arm-unknown-linux-musleabi" ]] ; then export LIBS="-latomic" ; fi && \
     PKG_CONFIG_PATH="${TARGET_PKG_CONFIG_PATH}" \
     AR="${TARGET_AR}" \
     LD="${TARGET_LD}" \
@@ -146,7 +168,8 @@ RUN echo "libcurl" && \
     LDFLAGS="${TARGET_LDFLAGS}" \
     CPPFLAGS="-I${TARGET_PREFIX}/include ${ARCH_CPPFLAGS}" \
     C_INCLUDE_PATH="${TARGET_PREFIX}/include" \
-    CC="${TARGET_CC} -O2 -fstack-protector-strong -flto -ffat-lto-objects -fPIE -pie -static --static" \
+    CFLAGS="-O2 -fstack-clash-protection -fstack-protector-strong -flto -ffat-lto-objects -fPIE -pie -fpic --static -Wl,-z,noexecstack -Wl,-z,relro,-z,now" \
+    CC="${TARGET_CC}" \
     ./configure \
       --with-sysroot="${SYSROOT}" \
       --host="${TARGET}" \
@@ -157,6 +180,11 @@ RUN echo "libcurl" && \
       --with-zlib \
       --with-openssl \
       --disable-ldap \
+      --disable-manual \
+      --without-libpsl \
+      --without-libgsasl \
+      --without-libidn2 \
+      --without-libssh2 \
       --enable-optimize \
       --with-ca-path=/etc/ssl/certs/ \
       --with-ca-bundle=/etc/ssl/certs/ca-certificates.crt \
@@ -166,6 +194,7 @@ RUN echo "libcurl" && \
     cd /tmp && rm -rf "curl-${CURL_VER}" && \
     # Move the compiled binaries out off the main musl bin to tbin
     mv -t "${TARGET_PREFIX}/tbin" "${TARGET_PREFIX}/bin/curl" "${TARGET_PREFIX}/bin/curl-config" && \
+    mv -vf "/usr/local/musl/${TARGET}/lib/libatomic.la_disabled" "/usr/local/musl/${TARGET}/lib/libatomic.la" && \
     # Default cleanups
     find /var/log -type f -delete && rm -rf "${TARGET_PREFIX}/share/man"
 
@@ -174,6 +203,7 @@ RUN echo "libcurl" && \
 RUN echo "PostgreSQL v11" && \
     curl -sSL "https://ftp.postgresql.org/pub/source/v${PQ_11_VER}/postgresql-${PQ_11_VER}.tar.gz" | tar xz && \
     cd "postgresql-${PQ_11_VER}" && \
+    if [[ "${TARGET}" == "arm-unknown-linux-musleabi" ]] ; then export LIBS="-latomic" ; fi && \
     PKG_CONFIG_PATH="${TARGET_PKG_CONFIG_PATH}" \
     AR="${TARGET_AR}" \
     LD="${TARGET_LD}" \
@@ -181,7 +211,8 @@ RUN echo "PostgreSQL v11" && \
     LDFLAGS="${TARGET_LDFLAGS}" \
     CPPFLAGS="-I${TARGET_PREFIX}/include ${ARCH_CPPFLAGS}" \
     C_INCLUDE_PATH="${TARGET_PREFIX}/include" \
-    CC="${TARGET_CC} -O2 -fstack-protector-strong -flto -ffat-lto-objects -fPIE -pie -static --static" \
+    CFLAGS=" -O2 -fstack-clash-protection -fstack-protector-strong -flto -ffat-lto-objects -fPIE -pie -fpic --static -Wl,-z,noexecstack -Wl,-z,relro,-z,now" \
+    CC="${TARGET_CC}" \
    ./configure \
       --host="${TARGET}" \
       --target="${TARGET}" \
@@ -203,6 +234,7 @@ RUN echo "PostgreSQL v11" && \
 RUN echo "PostgreSQL v15" && \
     curl -sSL "https://ftp.postgresql.org/pub/source/v${PQ_15_VER}/postgresql-${PQ_15_VER}.tar.gz" | tar xz && \
     cd "postgresql-${PQ_15_VER}" && \
+    if [[ "${TARGET}" == "arm-unknown-linux-musleabi" ]] ; then export LIBS="-latomic" ; fi && \
     PKG_CONFIG_PATH="${TARGET_PKG_CONFIG_PATH}" \
     AR="${TARGET_AR}" \
     LD="${TARGET_LD}" \
@@ -210,12 +242,13 @@ RUN echo "PostgreSQL v15" && \
     LDFLAGS="${TARGET_LDFLAGS}" \
     CPPFLAGS="-I${TARGET_PREFIX}/include ${ARCH_CPPFLAGS}" \
     C_INCLUDE_PATH="${TARGET_PREFIX}/include" \
-    CC="${TARGET_CC} -O2 -fstack-protector-strong -flto -ffat-lto-objects -fPIE -pie -static --static" \
+    CFLAGS="-O2 -fstack-clash-protection -fstack-protector-strong -flto -ffat-lto-objects -fPIE -pie -fpic --static -Wl,-z,noexecstack -Wl,-z,relro,-z,now -Wl,-z,noexecheap" \
+    CC="${TARGET_CC}" \
    ./configure \
       --host="${TARGET}" \
       --target="${TARGET}" \
       --without-readline \
-      --with-openssl \
+      --with-ssl=openssl \
       --disable-rpath \
       --with-system-tzdata=/usr/share/zoneinfo \
       --prefix="${TARGET_PREFIX}/pq15" && \
@@ -237,6 +270,7 @@ RUN echo "PostgreSQL v15" && \
       "${TARGET_AR}" x ../libpgcommon.a && \
       "${TARGET_AR}" x ../libpgport.a && \
       # Merge all these files again into one libpq.a file
+      # This is needed because the pq-sys crate only checks this file: https://github.com/sgrif/pq-sys/issues/27
       "${TARGET_AR}" csr libpq.a ./*.o && \
       # Move and cleanup
       mv -vf libpq.a ../libpq.a && \
@@ -258,10 +292,35 @@ RUN echo "SQLite3" && \
     LDFLAGS="${TARGET_LDFLAGS}" \
     CPPFLAGS="-I${TARGET_PREFIX}/include ${ARCH_CPPFLAGS}" \
     C_INCLUDE_PATH="${TARGET_PREFIX}/include" \
-    CC="${TARGET_CC} -O2 -fstack-protector-strong -flto -ffat-lto-objects -fPIE -pie -static --static" \
-    CFLAGS="-DSQLITE_CORE -D_POSIX_THREAD_SAFE_FUNCTIONS -DSQLITE_THREADSAFE=1 -DSQLITE_ENABLE_API_ARMOR -DSQLITE_DEFAULT_FOREIGN_KEYS=1 -DHAVE_USLEEP=1 -DSQLITE_ENABLE_MEMORY_MANAGEMENT" \
-    CFLAGS+=" -DSQLITE_ENABLE_FTS3 -DSQLITE_ENABLE_FTS3_PARENTHESIS -DSQLITE_ENABLE_FTS4 -DSQLITE_ENABLE_FTS5 -DSQLITE_SOUNDEX -DSQLITE_ENABLE_RTREE" \
-    CFLAGS+=" -DSQLITE_ENABLE_COLUMN_METADATA -DSQLITE_ENABLE_UNLOCK_NOTIFY -DSQLITE_USE_URI -DSQLITE_ENABLE_DBSTAT_VTAB -DSQLITE_MAX_VARIABLE_NUMBER=250000 -DSQLITE_MAX_EXPR_DEPTH=10000" \
+    CFLAGS="-O2 -fstack-clash-protection -fstack-protector-strong -flto -ffat-lto-objects -fPIE -pie -fpic --static -Wl,-z,noexecstack -Wl,-z,relro,-z,now" \
+    CC="${TARGET_CC}" \
+    # libsqlite3-sys crate default flags
+    CFLAGS+=" -DSQLITE_CORE" \
+    CFLAGS+=" -DSQLITE_DEFAULT_FOREIGN_KEYS=1" \
+    CFLAGS+=" -DSQLITE_ENABLE_API_ARMOR" \
+    CFLAGS+=" -DSQLITE_ENABLE_COLUMN_METADATA" \
+    CFLAGS+=" -DSQLITE_ENABLE_DBSTAT_VTAB" \
+    CFLAGS+=" -DSQLITE_ENABLE_FTS3" \
+    CFLAGS+=" -DSQLITE_ENABLE_FTS3_PARENTHESIS" \
+    CFLAGS+=" -DSQLITE_ENABLE_FTS5" \
+    CFLAGS+=" -DSQLITE_ENABLE_JSON1" \
+    CFLAGS+=" -DSQLITE_ENABLE_MEMORY_MANAGEMENT" \
+    CFLAGS+=" -DSQLITE_ENABLE_RTREE" \
+    CFLAGS+=" -DSQLITE_ENABLE_STAT2" \
+    CFLAGS+=" -DSQLITE_ENABLE_STAT4" \
+    CFLAGS+=" -DSQLITE_SOUNDEX" \
+    CFLAGS+=" -DSQLITE_THREADSAFE=1" \
+    CFLAGS+=" -DSQLITE_USE_URI" \
+    CFLAGS+=" -DHAVE_USLEEP=1" \
+    CFLAGS+=" -D_POSIX_THREAD_SAFE_FUNCTIONS" \
+    CFLAGS+=" -DHAVE_ISNAN" \
+    CFLAGS+=" -DHAVE_LOCALTIME_R" \
+    CFLAGS+=" -DSQLITE_ENABLE_UNLOCK_NOTIFY" \
+    # Alpine pkg default flags
+    CFLAGS+=" -DSQLITE_ENABLE_FTS4" \
+    CFLAGS+=" -DSQLITE_MAX_VARIABLE_NUMBER=250000" \
+    CFLAGS+=" -DSQLITE_MAX_EXPR_DEPTH=10000" \
+    CFLAGS+=" -DSQLITE_ENABLE_GEOPOLY=1" \
     ./configure \
       --with-sysroot="${SYSROOT}" \
       --host="${TARGET}" \
@@ -292,6 +351,19 @@ RUN echo "SQLite3" && \
 RUN echo "MariaDB Connector/C" && \
     curl -sSL "https://archive.mariadb.org/connector-c-${MARIADB_VER}/mariadb-connector-c-${MARIADB_VER}-src.tar.gz" | tar xz && \
     cd "mariadb-connector-c-${MARIADB_VER}-src" && \
+    # Download patches for mariadb from Alpine to fix building issues
+    curl -sSL --retry 3 -o arm32-shift-count.patch https://git.alpinelinux.org/aports/plain/main/mariadb-connector-c/arm32-shift-count.patch?id=9c5788682c99a0a102c340293d573d1f45823de5 && \
+    curl -sSL --retry 3 -o incorrect-sys-poll.patch https://git.alpinelinux.org/aports/plain/main/mariadb-connector-c/incorrect-sys-poll.patch?id=9c5788682c99a0a102c340293d573d1f45823de5 && \
+    curl -sSL --retry 3 -o unused-parameter.patch https://git.alpinelinux.org/aports/plain/main/mariadb-connector-c/unused-parameter.patch?id=9c5788682c99a0a102c340293d573d1f45823de5 && \
+    # Apply these patches
+    git apply --verbose arm32-shift-count.patch && \
+    git apply --verbose incorrect-sys-poll.patch && \
+    git apply --verbose unused-parameter.patch && \
+    if [[ "${TARGET}" == "arm-unknown-linux-musleabi" ]] ; then \
+      echo -e "%rename libgcc old_libgcc\n*libgcc:\n-latomic %(old_libgcc)" > /tmp/gcc-atomic-patch.specs && \
+      export _GCC_SPECS="-specs=/tmp/gcc-atomic-patch.specs" ; \
+    fi && \
+    # Build the patched version
     mkdir build && cd build && \
     PKG_CONFIG_PATH="${TARGET_PKG_CONFIG_PATH}" \
     AR="${TARGET_AR}" \
@@ -300,7 +372,8 @@ RUN echo "MariaDB Connector/C" && \
     LDFLAGS="${TARGET_LDFLAGS}" \
     CPPFLAGS="-I${TARGET_PREFIX}/include ${ARCH_CPPFLAGS}" \
     C_INCLUDE_PATH="${TARGET_PREFIX}/include" \
-    CC="${TARGET_CC} -O2 -fno-strict-aliasing -fstack-protector-strong -fPIE -pie -static --static" \
+    CFLAGS="${_GCC_SPECS} -O2 -fstack-clash-protection -fstack-protector-strong -fPIE -pie -fpic --static -Wl,-z,noexecstack -Wl,-z,relro,-z,now" \
+    CC="${TARGET_CC}" \
     cmake \
       -DCMAKE_IGNORE_PATH="/usr/include" \
       -DCMAKE_INSTALL_PREFIX="${TARGET_PREFIX}" \
@@ -309,7 +382,7 @@ RUN echo "MariaDB Connector/C" && \
       -DINSTALL_LIBDIR=lib \
       -DINSTALL_INCLUDEDIR=include/mysql \
       -DCMAKE_BUILD_TYPE=MinSizeRel \
-      -DWITH_EXTERNAL_ZLIB=OFF \
+      -DWITH_EXTERNAL_ZLIB=ON \
       -DWITH_SSL=OPENSSL \
       -DWITH_MYSQLCOMPAT=ON \
       -DWITH_UNIT_TESTS=OFF \
@@ -394,12 +467,13 @@ ENV HOST="x86_64-unknown-linux-gnu" \
     SQLITE3_STATIC=1 \
     SQLITE3_LIB_DIR="${TARGET_PREFIX}/lib" \
     SQLITE3_INCLUDE_DIR="${TARGET_PREFIX}/include" \
-    # If the ARCH_CPPFLAGS are set, we probably also need to pass them on to Rust.
+    # If the ARCH_CPPFLAGS is set, we probably also need to pass it on to Rust.
     # For example aarch64 needs `-mno-outline-atomic` set during builds.
     # Here we pass-on the ARCH_CPPFLAGS so that Rust is able to use the same
     # Also set the correct library path to make sure all pre-build libraries will be found.
-    TARGET_CFLAGS="-L${TARGET_PREFIX}/lib ${ARCH_CPPFLAGS}" \
-    TARGET_CXXFLAGS="-L${TARGET_PREFIX}/lib ${ARCH_CPPFLAGS}" \
+    # And some hardening flags, the same as used above to keep the binary as secure as possible.
+    TARGET_CFLAGS="-fstack-clash-protection -fstack-protector-strong -Wl,-z,noexecstack -Wl,-z,relro,-z,now -L${TARGET_PREFIX}/lib ${ARCH_CPPFLAGS}" \
+    TARGET_CXXFLAGS="-fstack-clash-protection -fstack-protector-strong -Wl,-z,noexecstack -Wl,-z,relro,-z,now -L${TARGET_PREFIX}/lib ${ARCH_CPPFLAGS}" \
     # Tell some crates that we are cross compiling
     CROSS_COMPILE=1
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ All versions of Rust v1.71.0 and above will all be build with MUSL v1.2.3 since 
 
 The following libraries are pre-build and marked as `STATIC` already via `ENV` variables so that the Rust Crates know there are static libraries available already.
 * ZLib (`v1.3`)
-* OpenSSL v1.1 (`v1.1.1w`) and OpenSSL v3.0 (`v3.0.11`)
+* OpenSSL v3.0 (`v3.0.11`)
 * cURL (`v8.3.0`)
 * PostgreSQL lib (`v11.21`) and PostgreSQL lib (`v15.4`)
 * SQLite (`v3.43.1`)
-* MariaDB Connector/C (`v3.3.5`) (MySQL Compatible)
+* MariaDB Connector/C (`v3.3.7`) (MySQL Compatible)
 
 
 ## Available architectures
@@ -34,8 +34,8 @@ Stables builds are automatically triggered if there is a new version available.
 
 
 ### OpenSSL v3.0
-If you want to use the OpenSSL v3.0 versions, you need to add `-openssl3` as the last postfix for the tag.
-The images without an extra postfix are using the default v1.1 version.
+Since 2023-09-29 i stopped building OpenSSL v1.1.1 since it's EOL.<br>
+Now only OpenSSL v3.0 is being build, the tags will be kept for a while.
 
 
 ### PostgreSQL v15
@@ -56,8 +56,6 @@ They do not seem to be used at all. If someone is using them, please open an iss
 | armv7-unknown-linux-musleabihf | armv7-musleabihf |
 | aarch64-unknown-linux-musl     | aarch64-musl     |
 | arm-unknown-linux-musleabi     | arm-musleabi     |
-| ~~arm-unknown-linux-musleabihf~~   | ~~arm-musleabihf~~   |
-| ~~armv5te-unknown-linux-musleabi~~ | ~~armv5te-musleabi~~ |
 
 To make use of these images you can either use them as your main `FROM` in your `Dockerfile` or use something like this:
 
@@ -133,8 +131,6 @@ This for example happens when using the `mimalloc` crate.
 | Cross Target                   |  RUSTFLAG             |
 | ------------------------------ | --------------------- |
 | arm-unknown-linux-musleabi     | `-Clink-arg=-latomic` |
-| ~~arm-unknown-linux-musleabihf~~   | ~~`-Clink-arg=-latomic`~~ |
-| ~~armv5te-unknown-linux-musleabi~~ | ~~`-Clink-arg=-latomic`~~ |
 
 <br>
 

--- a/test/multicrate/Cargo.toml
+++ b/test/multicrate/Cargo.toml
@@ -9,10 +9,13 @@ resolver = "2"
 default = []
 vendored_openssl = ["openssl/vendored"]
 
+[target.arm-unknown-linux-musleabi.dependencies.openssl-sys]
+version = "=0.9.92" # Fixed to v0.9.92 to prevent building issues with armv6
+
 [dependencies]
 # Make sure OpenSSL gets build, needed for Diesel, Curl and OpenSSL tests
 openssl = "*"
-openssl-sys = "=0.9.92" # Use this specific version to prevent armv6 linking issues
+openssl-sys = "*"
 
 # To get the library version used during the test
 pq-sys = "*"
@@ -34,6 +37,7 @@ serde_json = "1.0.*"
 # Deps for MiMalloc intergration
 mimalloc = { version = "*", features = ["secure"] }
 libmimalloc-sys = { version = "*", features = ["extended"] }
+
 
 # Deps for zlib testing
 [dependencies.flate2]

--- a/update_libs.py
+++ b/update_libs.py
@@ -142,7 +142,6 @@ def rustup_version():
 if __name__ == '__main__':
     PACKAGES = {
         # Print the latest versions available from there main mirrors/release-pages
-        'SSL1_1': mirrorver('https://ftp.openssl.org/source/', r'openssl-1\.\d\.\d+\w+', 'openssl-', r''),
         'SSL3_0': mirrorver('https://ftp.openssl.org/source/', r'openssl-3\.0\.\d+', 'openssl-', r''),
         'CURL': mirrorver('https://curl.se/download/', r'download\/curl-[89]\.\d+\.\d+', r'download/curl-', r'\.tar\.xz'),
         'ZLIB': mirrorver('https://zlib.net/', r'zlib-\d\.\d+', r'zlib-', r'\.tar\.gz'),
@@ -153,15 +152,17 @@ if __name__ == '__main__':
         # Also print some other version or from other resources just to compare
         '---': '---',
         'SSL3_X': mirrorver('https://ftp.openssl.org/source/', r'openssl-3\.\d\.\d+', 'openssl-', r''),
+        'SSL3_1': mirrorver('https://ftp.openssl.org/source/', r'openssl-3\.1\.\d+', 'openssl-', r''),
+        'SSL1_1': mirrorver('https://ftp.openssl.org/source/', r'openssl-1\.\d\.\d+\w+', 'openssl-', r''),
         'SSL_ARCH': convert_openssl_version(pkgver('openssl')),
         'CURL_ARCH': pkgver('curl'),
         'ZLIB_ARCH': pkgver('zlib'),
         'RUSTUP': rustup_version(),
         'PQ_ARCH': pkgver('postgresql'),
-        #'PQ_ALPINE': alpinever('postgresql14'),
+        'PQ_ALPINE': alpinever('postgresql15'),
         'SQLITE_ARCH': convert_sqlite_version(pkgver('sqlite')),
         'MARIADB_ARCH': aurver('mariadb-connector-c'),
-        #'MARIADB_ALPINE': alpinever('mariadb-connector-c'),
+        'MARIADB_ALPINE': alpinever('mariadb-connector-c'),
     }
 
     # Show a list of packages with current versions


### PR DESCRIPTION
- Updated MariaDB to v3.3.7
- Stopped building OpenSSL v1.1.1 since it's EOL
- Fixed a threading/atomic issue with OpenSSL by not adding `-static` to the OpenSSL build. This caused the `no-threads` to be triggered, and in turn didn't used actual `atomic` functions, and caused Vaultwarden to segfault/crash when downloading multiple icons in parallel.
- Added some extra hardening CFLAGS.
- Fixed a small GH Workflow item

With some special thanks to the people over in the #musl channel at libera. They helped me with some compile issues.

Should fix https://github.com/dani-garcia/vaultwarden/issues/3912