### PR TITLE
Fix Rust 1.78.0 warning

### DIFF
--- a/Dockerfile.musl-base
+++ b/Dockerfile.musl-base
@@ -474,7 +474,7 @@ RUN chmod 755 /root/ && \
       "\n"\
       "[target.${RUST_MUSL_CROSS_TARGET}]\n"\
       "linker = \"${RUST_MUSL_CROSS_TARGET}-ld\"\n"\
-      "\n" > /root/.cargo/config && \
+      "\n" > /root/.cargo/config.toml && \
     #
     # Link the strip command to musl-strip which is more widely used as the default strip command
     ln -sfnr "${TARGET_PREFIX}/bin/${TARGET}-strip" "${TARGET_PREFIX}/bin/musl-strip"


### PR DESCRIPTION
warning: `/root/.cargo/config` is deprecated in favor of `config.toml`
note: if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`

Encountered when building Vaultwarden with 1.78.0 at the "RUN USER=root cargo new --bin /app" step.